### PR TITLE
focus-visibleもpostcss-preset-env経由で使用するようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Base
 
 Other major libraries
 - [material-design-icons](https://google.github.io/material-design-icons/)
-- [focus-visible](https://github.com/WICG/focus-visible)
+-  [postcss-preset-env](https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env)
 
 ※As for the form validation, it is done using HTML only.  
 ※The pattern validation for Phone and Postal code is based on Japanese specifications.

--- a/css/style.css
+++ b/css/style.css
@@ -307,7 +307,7 @@ a {
   transition: background-color 0.3s;
 }
 
-.input-form .input-form__submit-button:focus:not(.focus-visible) {
+.input-form .input-form__submit-button:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,4 @@
 import '../css/style.css';
-import 'focus-visible';
 
 import './item-form';
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  plugins: [require('postcss-preset-env')],
+  plugins: [
+    require('postcss-preset-env')({
+      features: {
+        'focus-visible-pseudo-class': { enableClientSidePolyfills: true },
+      },
+    }),
+  ],
 };


### PR DESCRIPTION
## Issue 番号
<!-- ※マージとともクローズの場合は closes をつける -->
closes #10 

## 対応内容
- focus-visible も postcss-preset-env 経由で使用するようにした
  - 別パッケージのポリフィルを読み込むよう設定を追加
  - 元々、focus-visible をインポートしていたのを削除